### PR TITLE
chore(release): 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to `svelte-fusioncharts` are documented here.
+
+## 2.0.0
+
+Major release: one package for Svelte 4 and Svelte 5, declared peers, and shipped types. **No chart code changes are required**: the component, its props, and its events are unchanged.
+
+### Added
+- **Svelte 5 support** alongside Svelte 4, from a single published package.
+- **SvelteKit support.** Chart routes must disable SSR with `export const ssr = false`, because FusionCharts touches `document` at import.
+- TypeScript declarations (`index.d.ts`).
+- `peerDependencies` declared: `svelte ^4.0.0 || ^5.0.0` and `fusioncharts ^3.0.0 || ^4.0.0`. 1.1.0 declared none, so mismatches now surface at install rather than at runtime.
+- Consumer validation apps under `examples/`: Svelte 4 with webpack, Svelte 5 with Vite, and SvelteKit.
+- Compatibility and release CI across both Svelte majors, all three examples, and the published archive.
+
+### Changed
+- **The package ships source.** An `exports` map with a `svelte` condition replaces the prebuilt bundles; the consumer's bundler compiles it. That is what lets one package serve both majors.
+- Four Svelte 5 runtime fixes, including assigning `bind:chart` before `render()` so `beforeRender` handlers receive it.
+
+### Removed
+- **The CommonJS entry is removed.** `main: index.js` and the prebuilt `index.mjs` are replaced by the `exports` map. `require()` calls and deep-path imports must become imports by package name.
+- `renderAt` removed from samples and documentation. It has always been a no-op; the wrapper renders into its own element. The prop is retained for API parity.
+
+### Security
+- Addressed known OSV advisories in the dependency graph.
+
+### Compatibility
+- Applications on Svelte 3 should remain on `svelte-fusioncharts@1.0.x`.
+
+## 1.1.0
+
+Svelte 4 support and a modernised Rollup toolchain. `peerDependencies` were not declared in this release.
+
+## 1.0.0
+
+Initial release. Svelte 3.

--- a/README.md
+++ b/README.md
@@ -102,8 +102,10 @@ There are multiple ways to install `svelte-fusioncharts` component.
 **Install from NPM**
 
 ```
-npm install --save svelte-fusioncharts
+npm install --save svelte-fusioncharts fusioncharts
 ```
+
+`fusioncharts` is a peer dependency, so install it alongside the wrapper.
 
 See [npm documentation](https://docs.npmjs.com/) to know more about npm usage.
 

--- a/examples/svelte4-webpack/package-lock.json
+++ b/examples/svelte4-webpack/package-lock.json
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
-      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "version": "1.20.8",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.8.tgz",
+      "integrity": "sha512-JNcyFQ64OiijEkPzUBTCe+hyPXUD/3LEldGQ6iF5LR1w00mx9o7xtDWHXBY2iItjdCFGoilOLNQbH943ut7pHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1546,7 +1546,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.15.1",
+        "qs": "~6.16.0",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -1554,6 +1554,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/bonjour-service": {
@@ -2351,15 +2368,15 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.5",
+        "body-parser": "~1.20.3",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -2378,7 +2395,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.15.1",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -2416,9 +2433,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -4003,14 +4020,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-fusioncharts",
-  "version": "2.0.0-rc.0",
+  "version": "2.0.0",
   "description": "A simple and lightweight official Svelte component for FusionCharts JavaScript charting library. `svelte-fusioncharts` enables you to add JavaScript charts in your Svelte application or project without any hassle. Works with both Svelte 4 and Svelte 5.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump for the 2.0.0 GA release. Adds the changelog and includes the `fusioncharts` peer in the install command.